### PR TITLE
Update TEMPLATE-setup-my-sagemaker.sh

### DIFF
--- a/initsmnb/TEMPLATE-setup-my-sagemaker.sh
+++ b/initsmnb/TEMPLATE-setup-my-sagemaker.sh
@@ -19,7 +19,7 @@ get_bin_dir() {
 BIN_DIR=$(get_bin_dir)
 
 # Placeholder to store persistent config files
-mkdir ~/SageMaker/.initsmnb.d
+mkdir -p ~/SageMaker/.initsmnb.d
 
 ${BIN_DIR}/install-cli.sh
 ${BIN_DIR}/adjust-sm-git.sh 'Firstname Lastname' first.last@email.abc


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Added `-p` option to not raise error if `~/SageMaker/.initsmnb.d` if it already exists, this is useful when calling `setup-my-sagemaker.sh` after a notebook instance restart

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
