### PR TITLE
Relocate docker

### DIFF
--- a/initsmnb/TEMPLATE-setup-my-sagemaker.sh
+++ b/initsmnb/TEMPLATE-setup-my-sagemaker.sh
@@ -17,6 +17,7 @@ get_bin_dir() {
 }
 
 BIN_DIR=$(get_bin_dir)
+ENABLE_EXPERIMENTAL=0
 
 # Placeholder to store persistent config files
 mkdir -p ~/SageMaker/.initsmnb.d
@@ -37,14 +38,18 @@ ${BIN_DIR}/mount-efs-accesspoint.sh fsid,fsapid,mountpoint
 # These require jupyter lab restarted and browser reloaded, to see the changes.
 ${BIN_DIR}/patch-jupyter-config.sh
 
-# Disable jupyterlab git extension
-#~/anaconda3/envs/JupyterSystemEnv/bin/jupyter labextension disable '@jupyterlab/git'
+if [[ $ENABLE_EXPERIMENTAL == 1 ]]; then
+    # NOTE: comment or uncomment tweaks in this stanza as necessary.
 
-# Enable SageMaker local mode
-#ln -s ~/anaconda3/bin/docker-compose ~/.local/bin/
-#curl -sfL \
-#    https://raw.githubusercontent.com/aws-samples/amazon-sagemaker-local-mode/main/blog/pytorch_cnn_cifar10/setup.sh \
-#    | /bin/bash -s
+    # Disable jupyterlab git extension. For power git users, who don't like to
+    # be distracted by jlab's frequent status changes on lower-left status bar.
+    ~/anaconda3/envs/JupyterSystemEnv/bin/jupyter labextension disable '@jupyterlab/git'
+
+    ${BIN_DIR}/enable-sm-local-mode.sh
+    ${BIN_DIR}/change-docker-data-root.sh
+    ${BIN_DIR}/change-docker-tmp-dir.sh
+    ${BIN_DIR}/restart-docker.sh
+fi
 
 # Final checks and next steps to see the changes in-effect
 ${BIN_DIR}/final-check.sh

--- a/initsmnb/change-docker-data-root.sh
+++ b/initsmnb/change-docker-data-root.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+mkdir -p ~/SageMaker/.initsmnb.d/docker/
+
+sudo ~ec2-user/anaconda3/bin/python -c "
+import json
+
+with open('/etc/docker/daemon.json') as f:
+    d = json.load(f)
+
+d['data-root'] = '/home/ec2-user/SageMaker/.initsmnb.d/docker'
+
+with open('/etc/docker/daemon.json', 'w') as f:
+    json.dump(d, f, indent=4)
+    f.write('\n')
+"

--- a/initsmnb/change-docker-tmp-dir.sh
+++ b/initsmnb/change-docker-tmp-dir.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+FLAVOR=$(grep PRETTY_NAME /etc/os-release | cut -d'"' -f 2)
+if [[ $FLAVOR != "Amazon Linux 2" ]]; then
+    echo ${BASH_SOURCE[0]} does not support alinux instance.
+    exit 1
+fi
+
+# Give docker build a bit more space. E.g., as of Nov'21, building a custom
+# image based on the pytorch-1.10 DLC would fail due to exhausted /tmp.
+sudo sed -i \
+    's|^\[Service\]$|[Service]\nEnvironment="DOCKER_TMPDIR=/home/ec2-user/SageMaker/.initsmnb.d/tmp"|' \
+    /usr/lib/systemd/system/docker.service

--- a/initsmnb/enable-sm-local-mode.sh
+++ b/initsmnb/enable-sm-local-mode.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+ln -s ~/anaconda3/bin/docker-compose ~/.local/bin/
+curl -sfL \
+    https://raw.githubusercontent.com/aws-samples/amazon-sagemaker-local-mode/main/blog/pytorch_cnn_cifar10/setup.sh \
+    | /bin/bash -s

--- a/initsmnb/install-initsmnb.sh
+++ b/initsmnb/install-initsmnb.sh
@@ -20,6 +20,10 @@ declare -a SCRIPTS=(
     patch-bash-config.sh
     patch-jupyter-config.sh
     final-check.sh
+    enable-sm-local-mode.sh
+    change-docker-data-root.sh
+    change-docker-tmp-dir.sh
+    restart-docker.sh
 )
 
 declare -a NESTED_FILES=(

--- a/initsmnb/restart-docker.sh
+++ b/initsmnb/restart-docker.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+FLAVOR=$(grep PRETTY_NAME /etc/os-release | cut -d'"' -f 2)
+if [[ $FLAVOR != "Amazon Linux 2" ]]; then
+    echo ${BASH_SOURCE[0]} does not support alinux instance.
+    exit 1
+fi
+
+sudo mkdir -p ~ec2-user/SageMaker/.initsmnb.d/tmp/
+
+sudo systemctl daemon-reload
+sudo systemctl restart docker
+sudo systemctl show --property=Environment docker
+
+# Allow ec2-user access to the new tmp (which belongs to ec2-user anyway).
+sudo chmod 777 ~ec2-user/SageMaker/.initsmnb.d/tmp/
+sudo rm -fr ~ec2-user/SageMaker/.initsmnb.d/tmp/*


### PR DESCRIPTION
*Issue #, if available:* closed #11

*Description of changes:* Optional tweaks:

- relocate docker's data-root to `~/SageMaker/.initsmnb.d/docker/`
- relocate docker's tmpdir to `~/SageMaker/.initsmnb.d/tmp/`. This allows building large custom images (e.g., those based on PyTorch-1.10 DLC, as of Nov'21). In addition, this allows SageMaker local mode to use S3 inputs even if it requires space larger than what `/tmp` (i.e., root volume) can provide.

To enable: after installation, edit `~/SageMaker/initsmnb/setup-my-sagemaker.sh`, and change `EXPERIMENTAL` from 0 to 1.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
