### PR TITLE
System-wide JAVA_HOME to run .ipynb with pyspark

### DIFF
--- a/initsmnb/TEMPLATE-setup-my-sagemaker.sh
+++ b/initsmnb/TEMPLATE-setup-my-sagemaker.sh
@@ -38,6 +38,7 @@ ${BIN_DIR}/patch-bash-config.sh
 ${BIN_DIR}/fix-ipython.sh
 ${BIN_DIR}/init-vim.sh
 ${BIN_DIR}/install-cdk.sh
+${BIN_DIR}/fix-pyspark-smnb.sh
 ${BIN_DIR}/mount-efs-accesspoint.sh fsid,fsapid,mountpoint
 
 # These require jupyter lab restarted and browser reloaded, to see the changes.

--- a/initsmnb/fix-pyspark-smnb.sh
+++ b/initsmnb/fix-pyspark-smnb.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+echo "
+Setting system-wide JAVA_HOME to enable .ipynb to run pyspark-2.x (from the
+conda_python3 kernel), directly on this notebook instance.
+
+- This version of pyspark requires Java-1.8. However, since some time in 2021,
+  every .ipynb notebooks will automatically inherit
+  os.environ['JAVA_HOME'] == '/home/ec2-user/anaconda3/envs/JupyterSystemEnv',
+  and this OpenJDK-11 breaks the pyspark-2.x.
+
+- Note that setting JAVA_HOME in ~/.bashrc is not sufficient, because it affects
+  only pyspark scripts or REPL ran from a terminal.
+"
+
+echo 'export JAVA_HOME=/usr/lib/jvm/java' | sudo tee -a /etc/profile.d/java.sh

--- a/initsmnb/install-initsmnb.sh
+++ b/initsmnb/install-initsmnb.sh
@@ -67,6 +67,7 @@ declare -a SCRIPTS=(
     init-vim.sh
     install-cdk.sh
     QUICKSTART-CDK.md
+    fix-pyspark-smnb.sh
     mount-efs-accesspoint.sh
     patch-jupyter-config.sh
     change-jlab-ui.sh


### PR DESCRIPTION
*Issue #, if available:* closed #15

*Description of changes:* unbreak running .ipynb with pyspark-2.x (from the `conda_python3` kernel), directly on the notebook instance. This setting should free .ipynb from the need to implement the JAVA_HOME hack similar to this [mlmax screening notebook](https://github.com/awslabs/mlmax/blob/1d16af33ea5a3088e2d120d191ef68f1a97021ae/modules/environment/util/screening/screen-pyspark-smnb.ipynb) proposed by [this mlmax commit](https://github.com/awslabs/mlmax/commit/1d16af33ea5a3088e2d120d191ef68f1a97021ae).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
