### PR TITLE
Fix broken jlab due to nbclassic-0.4.0

### DIFF
--- a/initsmnb/upgrade-jupyter.sh
+++ b/initsmnb/upgrade-jupyter.sh
@@ -45,6 +45,7 @@ done
 declare -a PKGS=(
     ipython
     notebook
+    "nbclassic!=0.4.0"   # https://github.com/jupyter/nbclassic/issues/121
     ipykernel
     jupyterlab
     jupyter-server-proxy


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* do not use nbclassic-0.4.0 (see nbclassic's issue-121)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
