### PR TITLE
Add code-server

### DIFF
--- a/initsmnb/TEMPLATE-setup-my-sagemaker.sh
+++ b/initsmnb/TEMPLATE-setup-my-sagemaker.sh
@@ -74,5 +74,10 @@ if [[ $PLAIN_OLD_JLAB == 0 ]]; then
     ${BIN_DIR}/upgrade-jupyter.sh
 fi
 
+${BIN_DIR}/install-code-server.sh
+
+# Improve code-server's UX in dealing with persistent conda environments.
+~/anaconda3/bin/conda config --append envs_dirs ~/SageMaker/envs
+
 # Final checks and next steps to see the changes in-effect
 ${BIN_DIR}/final-check.sh

--- a/initsmnb/adjust-sm-git.sh
+++ b/initsmnb/adjust-sm-git.sh
@@ -37,8 +37,8 @@ echo Adjusting log aliases...
 git config --global alias.lol "log --graph --format=format:'%C(bold blue)%h%C(reset) - %C(bold green)(%ar)%C(reset) %C(white)%s%C(reset) %C(bold white)— %an%C(reset)%C(bold yellow)%d%C(reset)' --abbrev-commit --date=relative"
 #git config --global alias.lola "lol --all"  # SageMaker's git does not support alias chain :(
 git config --global alias.lola "! git lol --all"
-git config --global alias.lolc "! clear; git lol -\$(expr \`tput lines\` '*' 2 / 3)"
-git config --global alias.lolac "! clear; git lol --all -\$(expr \`tput lines\` '*' 2 / 3)"
+git config --global alias.lolc "! clear; git lol -\$(expr \`tput lines\` '*' 2 / 5)"
+git config --global alias.lolac "! clear; git lol --all -\$(expr \`tput lines\` '*' 2 / 5)"
 
 # Needed when notebook instance is not configured with a code repository.
 echo Setup steps for HTTPS connections to AWS CodeCommit repositories

--- a/initsmnb/final-check.sh
+++ b/initsmnb/final-check.sh
@@ -26,13 +26,25 @@ cat << EOF
 # Then, refresh your browser tab, and enjoy the new experience.               #
 EOF
 
+if [[ -e ~/HOWTO-RUN-CODE-SERVER.txt ]]; then
+    cat << 'EOF'
+#                                                                             #
+# --------------------------------------------------------------------------- #
+# NOTES:                                                                      #
+# --------------------------------------------------------------------------- #
+# Please refer to file ~/HOWTO-RUN-CODE-SERVER.txt on how to use code-server  #
+# (i.e., "VS Code in the browser") on this SageMaker notebook instance.       #
+EOF
+
+fi
+
 GIT_VERSION=$(git --version)
 if [[ "$GIT_VERSION" < "git version 2.28" ]]; then
-    cat << EOF
+    cat << 'EOF'
 #                                                                             #
-#-----------------------------------------------------------------------------#
+# --------------------------------------------------------------------------- #
 # NOTES:                                                                      #
-#-----------------------------------------------------------------------------#
+# --------------------------------------------------------------------------- #
 # The git version on this SageMaker classic notebook instance is older than   #
 # version 2.28, hence "git init" will default to branch "master".             #
 #                                                                             #

--- a/initsmnb/install-cli.sh
+++ b/initsmnb/install-cli.sh
@@ -49,6 +49,7 @@ declare -a PKG=(
 for i in "${PKG[@]}"; do
     ~/anaconda3/bin/pipx install $i
 done
+~/anaconda3/bin/pipx upgrade-all $i
 
 # pre-commit cache survives reboot (NOTE: can also set $PRE_COMMIT_HOME)
 mkdir -p ~/SageMaker/.initsmnb.d/.pre-commit.cache

--- a/initsmnb/install-cli.sh
+++ b/initsmnb/install-cli.sh
@@ -2,10 +2,10 @@
 
 FLAVOR=$(grep PRETTY_NAME /etc/os-release | cut -d'"' -f 2)
 if [[ $FLAVOR == "Amazon Linux 2" ]]; then
+    sudo amazon-linux-extras install -y epel
     # Slow install; hence disabled by default
-    #sudo amazon-linux-extras install -y epel
     #sudo yum install -y tig
-    sudo yum install -y htop tree dstat dos2unix
+    sudo yum install -y htop tree dstat dos2unix ncdu
 else
     sudo yum install -y htop tree dstat dos2unix tig
 fi

--- a/initsmnb/install-cli.sh
+++ b/initsmnb/install-cli.sh
@@ -49,7 +49,7 @@ declare -a PKG=(
 for i in "${PKG[@]}"; do
     ~/anaconda3/bin/pipx install $i
 done
-~/anaconda3/bin/pipx upgrade-all $i
+~/anaconda3/bin/pipx upgrade-all
 
 # pre-commit cache survives reboot (NOTE: can also set $PRE_COMMIT_HOME)
 mkdir -p ~/SageMaker/.initsmnb.d/.pre-commit.cache

--- a/initsmnb/install-code-server.sh
+++ b/initsmnb/install-code-server.sh
@@ -129,7 +129,7 @@ EOF
     // 1. press ctrl+shift+p
     // 2. type or select "Jupyter: Select Interpreter to Start Jupyter Server", then press Enter
     // 3. choose "Python 3.x.x ('JupyterSystemEnv') ~/anaconda3/envs/JupyterSystemEnv/bin/python"
-    "python.defaultInterpreterPath": "/home/ec2-user/anaconda3/envs/JupyterSystemEnv/bin/python3",
+    "python.defaultInterpreterPath": "/home/ec2-user/anaconda3/envs/JupyterSystemEnv/bin/python",
 
     "terminal.integrated.env.osx": {
         "PYTHONPATH": "${workspaceFolder}/src:${env:PYTHONPATH}"

--- a/initsmnb/install-code-server.sh
+++ b/initsmnb/install-code-server.sh
@@ -361,22 +361,34 @@ show_usage() {
          | sed 's/[\\()]//g' \
          | sed "s/|${SMNB_NAME}\.notebook/.notebook/"
     )
-    echo "################################################################################"
-    echo "# Steps to run Code Server (filename: ~/HOWTO-RUN-CODE-SERVER.txt)"
-    echo "################################################################################"
-    echo "1. Open the terminal and run:"
-    echo
-    echo "       code-server --auth=none --disable-telemetry --disable-update-check"
-    echo
-    echo "2. Then, open a new browser tab and go to:"
-    echo
-    echo "       $SMNB_URL/proxy/8080/"
-    echo "################################################################################"
+
+    cat << EOF
+################################################################################
+# Steps to run Code Server (filename: ~/HOWTO-RUN-CODE-SERVER.txt)
+################################################################################
+1. Open the terminal and run:
+
+       code-server --auth=none --disable-telemetry --disable-update-check
+
+2. Then, open a new browser tab and go to:
+
+       $SMNB_URL/proxy/8080/"
+################################################################################
+EOF
 }
 
 
 install_code_server
 if [[ ! -e ~/.local/share/code-server/_SUCCESS ]]; then
+    echo "Cannot detect ~/.local/share/code-server/_SUCCESS"
+    cat << 'EOF'
+
+Cannot find ~/local/share/code-server/_SUCCESS.
+Installing code-server extensions related to Python-based data science.
+Please be patient, as this may take a few minutes.
+
+EOF
+
     install_ext
     apply_setting
     touch ~/.local/share/code-server/_SUCCESS

--- a/initsmnb/install-code-server.sh
+++ b/initsmnb/install-code-server.sh
@@ -362,7 +362,7 @@ show_usage() {
          | sed "s/|${SMNB_NAME}\.notebook/.notebook/"
     )
     echo "################################################################################"
-    echo "# Steps to run Code Server"
+    echo "# Steps to run Code Server (filename: ~/HOWTO-RUN-CODE-SERVER.txt)"
     echo "################################################################################"
     echo "1. Open the terminal and run:"
     echo

--- a/initsmnb/install-code-server.sh
+++ b/initsmnb/install-code-server.sh
@@ -372,7 +372,7 @@ show_usage() {
 
 2. Then, open a new browser tab and go to:
 
-       $SMNB_URL/proxy/8080/"
+       $SMNB_URL/proxy/8080/
 ################################################################################
 EOF
 }
@@ -382,11 +382,20 @@ install_code_server
 if [[ ! -e ~/.local/share/code-server/_SUCCESS ]]; then
     cat << 'EOF'
 
-###########################################################################
-# Cannot find ~/local/share/code-server/_SUCCESS.                         #
-# Installing code-server extensions related to Python-based data science. #
-# Please be patient, as this may take a few minutes.                      #
-###########################################################################
+##############################################################################
+# Cannot find ~/local/share/code-server/_SUCCESS.                            #
+#                                                                            #
+# It seems like this is the first time ever the install-code-server.sh runs  #
+# on this SageMaker notebook instance.                                       #
+#                                                                            #
+# As such, I'm going to install several code-server extensions related to    #
+# Python data science to boost your development experience.                  #
+#                                                                            #
+# Please be patient, as this one-time install may take a few minutes.        #
+#                                                                            #
+# The next time you restart this SageMaker notebook instance, the extensions #
+# will still be available, and you shouldn't see this message anymore.       #
+##############################################################################
 
 EOF
 

--- a/initsmnb/install-code-server.sh
+++ b/initsmnb/install-code-server.sh
@@ -380,12 +380,13 @@ EOF
 
 install_code_server
 if [[ ! -e ~/.local/share/code-server/_SUCCESS ]]; then
-    echo "Cannot detect ~/.local/share/code-server/_SUCCESS"
     cat << 'EOF'
 
-Cannot find ~/local/share/code-server/_SUCCESS.
-Installing code-server extensions related to Python-based data science.
-Please be patient, as this may take a few minutes.
+###########################################################################
+# Cannot find ~/local/share/code-server/_SUCCESS.                         #
+# Installing code-server extensions related to Python-based data science. #
+# Please be patient, as this may take a few minutes.                      #
+###########################################################################
 
 EOF
 

--- a/initsmnb/install-initsmnb.sh
+++ b/initsmnb/install-initsmnb.sh
@@ -77,6 +77,7 @@ declare -a SCRIPTS=(
     change-docker-tmp-dir.sh
     restart-docker.sh
     upgrade-jupyter.sh
+    install-code-server.sh
 )
 
 declare -a NESTED_FILES=(

--- a/initsmnb/install-vscode.sh
+++ b/initsmnb/install-vscode.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+mkdir -p \
+    ~/.local/share/ \
+    ~/SageMaker/.initsmnb.d/.local/share/code-server/ \
+
+[[ -d ~/.local/share/code-server ]] \
+    || ln -s ~/SageMaker/.initsmnb.d/.local/share/code-server ~/.local/share/code-server
+
+curl -fsSL https://code-server.dev/install.sh | sh
+rm -fr ~/.cache/code-server/
+
+SMNB_NAME=$(cat /opt/ml/metadata/resource-metadata.json  | jq -r '.ResourceName')
+SMNB_URL=$(cat /etc/opt/ml/sagemaker-notebook-instance-config.json \
+     | jq -r '.notebook_uri' \
+     | sed 's/[\\()]//g' \
+     | sed "s/|${SMNB_NAME}\.notebook/.notebook/"
+)
+echo "################################################################################"
+echo "# Steps to run VSCode"
+echo "################################################################################"
+echo "1. Open the terminal and run:"
+echo
+echo "       code-server --auth-none"
+echo
+echo "2. Then, open a new browser tab and go to:"
+echo
+echo "       $SMNB_URL/proxy/8080/"
+echo "################################################################################"
+
+# --user-data-dir
+# --extension-dir
+# --install-extension
+
+rm -fr
+    ~/.local/share/code-server/CachedExtensionVSIXs/ \
+    ~/.local/share/code-server/CachedExtensions/
+
+#{
+#    "workbench.colorTheme": "Default Dark+",
+#    "workbench.startupEditor": "none",
+#    "editor.cursorBlinking": "solid"
+#}

--- a/initsmnb/install-vscode.sh
+++ b/initsmnb/install-vscode.sh
@@ -1,43 +1,385 @@
 #!/bin/bash
 
-mkdir -p \
-    ~/.local/share/ \
-    ~/SageMaker/.initsmnb.d/.local/share/code-server/ \
+install_code_server() {
+    mkdir -p ~/.local/share/ ~/SageMaker/.initsmnb.d/.local/share/code-server/
+    [[ -d ~/.local/share/code-server ]] \
+        || ln -s ~/SageMaker/.initsmnb.d/.local/share/code-server ~/.local/share/code-server
 
-[[ -d ~/.local/share/code-server ]] \
-    || ln -s ~/SageMaker/.initsmnb.d/.local/share/code-server ~/.local/share/code-server
+    curl -fsSL https://code-server.dev/install.sh | sh
+    rm -fr ~/.cache/code-server/
+}
 
-curl -fsSL https://code-server.dev/install.sh | sh
-rm -fr ~/.cache/code-server/
+install_ext() {
+    # [20221023] https://github.com/verdimrc/linuxcfg/blob/main/vscode/extensions.json
+    #
+    # Code-server cannot install some extensions, which is expected.
+    # See: https://github.com/coder/code-server/discussions/2345.
+    declare -a EXT=(
+        "adpyke.vscode-sql-formatter"
+        "bierner.markdown-mermaid"
+        "bungcip.better-toml"
+        "christian-kohler.path-intellisense"
+        "DavidAnson.vscode-markdownlint"
+        "donjayamanne.githistory"
+        "donjayamanne.python-environment-manager"
+        "EditorConfig.EditorConfig"
+        "emilast.LogFileHighlighter"
+        "Gruntfuggly.todo-tree"
+        "IBM.output-colorizer"
+        "leonhard-s.python-sphinx-highlight"
+        "mechatroner.rainbow-csv"
+        "mhutchie.git-graph"
+        "mikestead.dotenv"
+        "ms-python.black-formatter"
+        "ms-python.isort"
+        "ms-python.python"
+        "ms-toolsai.vscode-jupyter-powertoys"
+        "ms-vscode.live-server"
+        "ms-vscode-remote.remote-ssh"
+        "ms-vscode-remote.remote-ssh-edit"
+        "njpwerner.autodocstring"
+        "redhat.vscode-yaml"
+        "shardulm94.trailing-spaces"
+        "stkb.rewrap"
+        "tomoki1207.pdf"
+        "usernamehw.errorlens"
+        "VisualStudioExptTeam.vscodeintellicode"
+        "yzhang.markdown-all-in-one"
+    )
+    for i in "${EXT[@]}"; do
+        code-server --install-extension $i
+    done
+}
 
-SMNB_NAME=$(cat /opt/ml/metadata/resource-metadata.json  | jq -r '.ResourceName')
-SMNB_URL=$(cat /etc/opt/ml/sagemaker-notebook-instance-config.json \
-     | jq -r '.notebook_uri' \
-     | sed 's/[\\()]//g' \
-     | sed "s/|${SMNB_NAME}\.notebook/.notebook/"
-)
-echo "################################################################################"
-echo "# Steps to run VSCode"
-echo "################################################################################"
-echo "1. Open the terminal and run:"
-echo
-echo "       code-server --auth-none"
-echo
-echo "2. Then, open a new browser tab and go to:"
-echo
-echo "       $SMNB_URL/proxy/8080/"
-echo "################################################################################"
+apply_setting() {
+    # [20221023] https://github.com/verdimrc/linuxcfg/blob/main/vscode/keybindings.json
+    cat << 'EOF' > ~/.local/share/code-server/User/keybindings.json
+// Place your key bindings in this file to override the defaults
+[
+    // Since vscode-1.44, OSX + iTerm2 needs this new setting to pass
+    // alt-backspace correctly to bash.
+    {
+        "key": "alt+backspace",
+        "command": "deleteWordPartLeft",
+        "when": "terminalFocus && isMac"
+    },
+    // Re-assign ctrl-f in terminal, to remove conflict with vim (Linux)
+    {
+        "key": "ctrl+shift+f",
+        "command": "workbench.action.terminal.focusFind",
+        "when": "terminalFindFocused || terminalFocus"
+    },
+    {
+        "key": "ctrl+f",
+        "command": "-workbench.action.terminal.focusFind",
+        "when": "terminalFindFocused || terminalFocus"
+    },
 
-# --user-data-dir
-# --extension-dir
-# --install-extension
+    // Remove alt-w (Linux), since my zsh remaps alt-w to backward-kill-dir
+    // TODO: figure out the correct "when", rather then disable at all.
+    {
+        "key": "alt+w",
+        "command": "-workbench.action.terminal.toggleFindWholeWord"
+    }
+]
+EOF
 
-rm -fr
-    ~/.local/share/code-server/CachedExtensionVSIXs/ \
-    ~/.local/share/code-server/CachedExtensions/
+    # [20221023] https://github.com/verdimrc/linuxcfg/blob/main/vscode/settings.json
+    #
+    # Notable changes:
+    # - "python.languageServer" from "Pylance" to "Jedi" (https://github.com/coder/code-server/issues/1938)
+    cat << 'EOF' > ~/.local/share/code-server/User/settings.json
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // initsmnb specific
+    ///////////////////////////////////////////////////////////////////////////
+    "workbench.colorTheme": "Default Dark+",
+    "terminal.integrated.shell.linux": "/bin/bash",
 
-#{
-#    "workbench.colorTheme": "Default Dark+",
-#    "workbench.startupEditor": "none",
-#    "editor.cursorBlinking": "solid"
-#}
+
+    ///////////////////////////////////////////////////////////////////////////
+    // OFF TELEMETRIES (LIFTED TO NEAR TOP FOR VISIBILITY
+    ///////////////////////////////////////////////////////////////////////////
+
+    // Global telemetries
+    "telemetry.enableCrashReporter": false, // Deprecated since v1.61 Oct'21
+    "telemetry.enableTelemetry": false, // Deprecated since v1.61 Oct'21
+    "telemetry.telemetryLevel": "off", // Since v1.61 Oct'21
+    "python.experiments.enabled": false,
+    "workbench.enableExperiments": false,
+
+    // Extensions telemetries
+    "aws.telemetry": false,
+    "gitlens.advanced.telemetry.enabled": false,
+    "redhat.telemetry.enabled": false,
+
+
+    ///////////////////////////////////////////////////////////////////////////
+    // EXPERIMENTAL OR PREVIEW FEATURES
+    ///////////////////////////////////////////////////////////////////////////
+    "markdown.experimental.updateLinksOnFileMove.enabled": "always", // aug22
+
+
+    ///////////////////////////////////////////////////////////////////////////
+    // HYPER-PERSONALIZED STANZA
+    ///////////////////////////////////////////////////////////////////////////
+
+    // Python paths.
+    // NOTE: if you change "python.defaultInterpreterPath", then on code-server UI:
+    // 1. press ctrl+shift+p
+    // 2. type or select "Jupyter: Select Interpreter to Start Jupyter Server", then press Enter
+    // 3. choose "Python 3.x.x ('JupyterSystemEnv') ~/anaconda3/envs/JupyterSystemEnv/bin/python"
+    "python.defaultInterpreterPath": "/home/ec2-user/anaconda3/envs/JupyterSystemEnv/bin/python3",
+
+    "terminal.integrated.env.osx": {
+        "PYTHONPATH": "${workspaceFolder}/src:${env:PYTHONPATH}"
+    },
+    "terminal.integrated.env.linux": {
+        "PYTHONPATH": "${workspaceFolder}/src:${env:PYTHONPATH}"
+    },
+
+    // To use binaries outside of selected python interpreter, e.g., those installed by pipx
+    //"python.linting.flake8Path": "/usr/local/bin/flake8",
+    //"python.linting.mypyPath": "/usr/local/bin/mypy",
+    //"python.linting.pydocstylePath": "/home/verdi/.local/bin/pydocstyle",
+
+    // GUI: vscode
+    "window.zoomLevel": 0,
+    //"editor.fontFamily": "Monego",
+    "debug.console.fontSize": 11,
+    "editor.fontSize": 11,
+    //"editor.lineHeight": 18,
+    "terminal.integrated.fontSize": 11,
+    "extensions.ignoreRecommendations": true, // Default to true; set false if you prefer.
+    "workbench.colorCustomizations": {
+        "editor.lineHighlightBackground": "#2d2d2d" // For dark theme
+    },
+    // "window.titleBarStyle": "custom",
+    // GUI: extensions
+    "markdown.preview.fontSize": 16, // yzhang.markdown-all-in-one
+
+
+    ///////////////////////////////////////////////////////////////////////////
+    // OTHER CONFIGS
+    ///////////////////////////////////////////////////////////////////////////
+
+    // File exclusions
+    "files.exclude": {
+        "**/.git": true,
+        "**/.svn": true,
+        "**/.hg": true,
+        "**/CVS": true,
+        "**/.DS_Store": true,
+        "**/._*": true,
+        "**/__pycache__": true,
+        "**/.ipynb_checkpoints": true,
+        "**/.*_cache": true,
+        "**/.tox": true
+    },
+    "files.watcherExclude": {
+        "**/.git/objects/**": true,
+        "**/.git/subtree-cache/**": true,
+        "**/node_modules/*/**": true,
+        "**/._*/**": true,
+        "**/__pycache__/**": true,
+        "**/.ipynb_checkpoints/**": true,
+        "**/.*_cache/**": true,
+        "**/.tox/**": true
+    },
+
+    "files.associations": {
+        "Dockerfile.cpu": "dockerfile",
+        "Dockerfile.gpu": "dockerfile"
+    },
+
+    // Javascript
+    "[javascript]": {
+        "editor.defaultFormatter": "esbenp.pettier-vscode",
+        "editor.codeActionsOnSave": {
+            // "source.fixAll.eslint": false,
+            "source.fixAll": false  // Don't like. Too aggressive during dev.
+        }
+    },
+
+    // Python
+    "debug.allowBreakpointsEverywhere": true,
+    "jupyter.askForKernelRestart": false,
+    "jupyter.debugJustMyCode": false,
+    "jupyter.disableJupyterAutoStart": true,
+    "jupyter.magicCommandsAsComments": true,
+    "jupyter.sendSelectionToInteractiveWindow": true,
+    "notebook.lineNumbers": "on",
+    "python.formatting.provider": "black",
+    "[python]": {
+        "editor.defaultFormatter": "ms-python.black-formatter",
+        "editor.codeActionsOnSave": {
+            "source.fixAll": false // Don't like. Import can be removed unpredictably.
+        }
+    },
+    "python.analysis.inlayHints.variableTypes": true,
+    "python.analysis.inlayHints.functionReturnTypes": true,
+    "python.languageServer": "jedi",
+    "python.linting.enabled": true,
+    "python.linting.flake8Enabled": true,
+    "python.linting.mypyEnabled": true,
+    "python.linting.mypyArgs": [ "--show-error-codes" ],
+    "python.linting.pydocstyleEnabled": false,
+    "python.showStartPage": false,
+    "python.testing.pytestEnabled": true,
+    "python.testing.unittestEnabled": false,
+
+    // Workbench & editor
+    "breadcrumbs.enabled": true,
+    "editor.bracketPairColorization.enabled": true,
+    "editor.formatOnSave": true,
+    //"editor.formatOnSaveMode": "modifications",  //Not supported with Black
+    "editor.codeActionsOnSave": {
+        "source.fixAll.markdownlint": true, // Extension davidanson.vscode-markdownlint
+        "source.organizeImports": true
+    },
+    "editor.minimap.enabled": false,
+    "editor.parameterHints.cycle": true,
+    "editor.renderLineHighlight": "all",
+    //"editor.renderWhitespace": "trailing",
+    "editor.renderControlCharacters": false,
+    "editor.rulers": [
+        80,
+        100
+    ],
+    "editor.stickyScroll.enabled": true,
+    "editor.stickyTabStops": true,
+    "editor.suggestSelection": "first",
+    "editor.wordWrapColumn": 100,
+    "explorer.confirmDelete": false,
+    "explorer.confirmDragAndDrop": false,
+    "explorer.openEditors.visible": 0,
+    "files.eol": "\n",
+    "git.terminalAuthentication": false,
+    "scm.diffDecorationsGutterPattern": {
+        "added": true
+    },
+    "json.format.keepLines": true,
+    "outline.showVariables": false,
+    "terminal.integrated.enableMultiLinePasteWarning": false,
+    "terminal.integrated.lineHeight": 1.2,
+    "terminal.integrated.localEchoLatencyThreshold": -1,
+    "terminal.integrated.persistentSessionReviveProcess": "never",
+    "terminal.integrated.enablePersistentSessions": false,
+    "terminal.integrated.shellIntegration.enabled": true, // Jul22 default is on
+    "workbench.editor.decorations.colors": true,
+    "workbench.editor.decorations.badges": true,
+    // "workbench.editor.enablePreviewFromCodeNavigation": true,
+    "workbench.reduceMotion": "on",
+    "workbench.startupEditor": "none",
+    "workbench.tree.indent": 20,
+
+    // Shortcuts in integrated terminal
+    "terminal.integrated.allowChords": false, // send ctrl+k to integrated terminal
+    "terminal.integrated.commandsToSkipShell": [
+        // Linux: send ctrl+e to integrated terminal
+        "-workbench.action.quickOpen",
+
+        // alt-backspace to behave like in Bash
+        "-workbench.action.terminal.deleteWordLeft"
+    ],
+    //"terminal.integrated.macOptionIsMeta": true, // Allow alt-{f,b,.} in integrated terminal. See https://github.com/Microsoft/vscode/issues/11314
+    "terminal.integrated.sendKeybindingsToShell": true,
+    "terminal.integrated.showExitAlert": false,
+
+    // Extensions
+    "autoDocstring.docstringFormat": "google",
+    "aws.samcli.location": "/usr/local/bin/sam",
+    "aws.profile": "default",
+    "gitlens.hovers.currentLine.over": "line",
+    // "markdown.extension.preview.autoShowPreviewToSide": true,
+    "[markdown]": {
+        "editor.defaultFormatter": "yzhang.markdown-all-in-one"
+    },
+    "remote.SSH.defaultExtensions": [
+        "adpyke.vscode-sql-formatter",
+        "bierner.markdown-mermaid",
+        "bungcip.better-toml",
+        "christian-kohler.path-intellisense",
+        "davidanson.vscode-markdownlint",
+        "donjayamanne.githistory",
+        "donjayamanne.python-environment-manager",
+        "editorconfig.editorconfig",
+        //"eamodio.gitlens",
+        "gruntfuggly.todo-tree",
+        "mechatroner.rainbow-csv",
+        "mhutchie.git-graph",
+        "ms-python.black-formatter",
+        "ms-python.isort",
+        "ms-python.vscode-pylance",
+        "ms-python.python",
+        "ms-toolsai.jupyter",
+        "ms-toolsai.vscode-jupyter-powertoys",
+        "ms-vscode.live-server",
+        "njpwerner.autodocstring",
+        "redhat.vscode-yaml",
+        "shardulm94.trailing-spaces",
+        "stkb.rewrap",
+        "tomoki1207.pdf",
+        "visualstudioexptteam.vscodeintellicode",
+        "yzhang.markdown-all-in-one"
+    ],
+    "rewrap.wrappingColumn": 100,
+    "sql-formatter.uppercase": true,
+    "todo-tree.general.tags": [
+        "BUG",
+        "HACK",
+        "FIXME",
+        "TODO",
+        "XXX",
+        "[ ]",
+        "[x]"
+    ],
+    "todo-tree.highlights.customHighlight": {
+        "TODO": {
+            "foreground": "yellow"
+        },
+        "FIXME": {
+            "foreground": "red"
+        }
+    },
+    "todo-tree.highlights.defaultHighlight": {
+        "opacity": 0,
+        "fontStyle": "italic",
+        "fontWeight": "bold"
+    },
+    "todo-tree.regex.regex": "(//|#|<!--|;|/\\*|^|^\\s*(-|\\d+.))\\s*($TAGS)",
+    "todo-tree.tree.showScanModeButton": true,
+    "vsintellicode.modify.editor.suggestSelection": "automaticallyOverrodeDefaultValue"
+}
+EOF
+}
+
+show_usage() {
+    local SMNB_NAME=$(cat /opt/ml/metadata/resource-metadata.json  | jq -r '.ResourceName')
+    local SMNB_URL=$(cat /etc/opt/ml/sagemaker-notebook-instance-config.json \
+         | jq -r '.notebook_uri' \
+         | sed 's/[\\()]//g' \
+         | sed "s/|${SMNB_NAME}\.notebook/.notebook/"
+    )
+    echo "################################################################################"
+    echo "# Steps to run Code Server"
+    echo "################################################################################"
+    echo "1. Open the terminal and run:"
+    echo
+    echo "       code-server --auth=none --disable-telemetry --disable-update-check"
+    echo
+    echo "2. Then, open a new browser tab and go to:"
+    echo
+    echo "       $SMNB_URL/proxy/8080/"
+    echo "################################################################################"
+}
+
+
+install_code_server
+if [[ ! -e ~/.local/share/code-server/_SUCCESS ]]; then
+    install_ext
+    apply_setting
+    touch ~/.local/share/code-server/_SUCCESS
+fi
+rm -fr ~/.local/share/code-server/{CachedExtensionVSIXs,CachedExtensions}/
+show_usage | tee ~/HOWTO-RUN-CODE-SERVER.txt

--- a/initsmnb/patch-bash-config.sh
+++ b/initsmnb/patch-bash-config.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-cat << EOF >> ~/.bash_profile
+cat << 'EOF' >> ~/.bash_profile
 
 # Workaround: when starting tmux from conda env, deactivate in all tmux sessions.
-if [[ ! -z "\$TMUX" ]]; then
-    for i in \$(seq \$CONDA_SHLVL); do
+if [[ ! -z "$TMUX" ]]; then
+    for i in $(seq $CONDA_SHLVL); do
         conda deactivate
     done
 fi
@@ -13,10 +13,10 @@ EOF
 
 # PS1 must preceed conda bash.hook, to correctly display CONDA_PROMPT_MODIFIER
 cp ~/.bashrc{,.ori}
-cat << EOF > ~/.bashrc
+cat << 'EOF' > ~/.bashrc
 git_branch() {
-   local branch=\$(/usr/bin/git branch 2>/dev/null | grep '^*' | colrm 1 2)
-   [[ "\$branch" == "" ]] && echo "" || echo "(\$branch) "
+   local branch=$(/usr/bin/git branch 2>/dev/null | grep '^*' | colrm 1 2)
+   [[ "$branch" == "" ]] && echo "" || echo "($branch) "
 }
 
 # All colors are bold
@@ -26,8 +26,7 @@ COLOR_YELLOW="\[\033[1;33m\]"
 COLOR_OFF="\[\033[0m\]"
 
 # Define PS1 before conda bash.hook, to correctly display CONDA_PROMPT_MODIFIER
-export PS1="[\$COLOR_GREEN\w\$COLOR_OFF] \$COLOR_PURPLE\\\$(git_branch)\$COLOR_OFF\\\$ "
-
+export PS1="[$COLOR_GREEN\w$COLOR_OFF] $COLOR_PURPLE\$(git_branch)$COLOR_OFF\$ "
 EOF
 
 
@@ -35,7 +34,7 @@ EOF
 cat ~/.bashrc.ori >> ~/.bashrc
 
 # Custom aliases
-cat << EOF >> ~/.bashrc
+cat << 'EOF' >> ~/.bashrc
 
 alias ll='ls -alF --color=auto'
 
@@ -53,6 +52,13 @@ ACCOUNT=$(aws sts get-caller-identity | grep Account | awk '{print $2}' | sed -e
 EC2_AVAIL_ZONE=`curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone`
 REGION="`echo \"$EC2_AVAIL_ZONE\" | sed 's/[a-z]\$//'`"
 
+SMNB_NAME=$(cat /opt/ml/metadata/resource-metadata.json  | jq -r '.ResourceName')
+SMNB_URL=$(cat /etc/opt/ml/sagemaker-notebook-instance-config.json \
+    | jq -r '.notebook_uri' \
+    | sed 's/[\\()]//g' \
+    | sed "s/|${SMNB_NAME}\.notebook/.notebook/"
+)
+
 # Add environment variables
 cat << EOF >> ~/.bashrc
 
@@ -68,6 +74,10 @@ export EC2_AVAIL_ZONE=$EC2_AVAIL_ZONE
 # CDK's environment variables
 export CDK_DEFAULT_ACCOUNT=$ACCOUNT
 export CDK_DEFAULT_REGION=$REGION
+
+# SageMaker notebook variables
+export SMNB_NAME=$SMNB_NAME
+export SMNB_URL=$SMNB_URL
 EOF
 
 # Provide reference on how to regenerate the values.
@@ -80,5 +90,17 @@ cat << 'EOF' >> ~/.bashrc
 #AWS_ACCOUNT=$(aws sts get-caller-identity | grep Account | awk '{print $2}' | sed -e 's/"//g' -e 's/,//g')
 #EC2_AVAIL_ZONE=`curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone`
 #AWS_DEFAULT_REGION="`echo \"$EC2_AVAIL_ZONE\" | sed 's/[a-z]\$//'`"
+################################################################################
+
+################################################################################
+# NOTE: these are left as a left as a reference in case you want to regenerate
+# the above values.
+################################################################################
+#SMNB_NAME=$(cat /opt/ml/metadata/resource-metadata.json  | jq -r '.ResourceName')
+#SMNB_URL=$(cat /etc/opt/ml/sagemaker-notebook-instance-config.json \
+#    | jq -r '.notebook_uri' \
+#    | sed 's/[\\()]//g' \
+#    | sed "s/|${SMNB_NAME}\.notebook/.notebook/"
+#)
 ################################################################################
 EOF


### PR DESCRIPTION
*Issue #, if available:* closes #26

*Description of changes:*
- install [code-server](https://github.com/coder/code-server). In addition, perform a one-time setup of extensions+config related to Python data science
- improve the handling of persistent Conda environment. Now `conda` CLI (and by extension, code-server) recognizes `~/SageMaker/envs/` as one of conda's `envs_dirs`.
- add `ncdu` CLI.
- export `SMNB_NAME` and `SMNB_URL` environment variables.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
